### PR TITLE
add a Makefile receipe to test config gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,7 @@ container-image:
 .PHONY: generate-config
 generate-config:
 	docker run -v `pwd`:/data:Z surajd/kedgeschema
+
+.PHONY: test-generate-config
+test-generate-config:
+	docker run surajd/kedgeschema


### PR DESCRIPTION
This make receipe will only test config generation but will
not save it anywhere.