### PR TITLE
Kedge all structs were moved from spec.go to types.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This will create OpenAPI configuration for [kedge](https://github.com/kedgeproject/kedge),
 but make sure you have Kubernetes Swagger OpenAPI schema [`swagger.json`](https://github.com/kubernetes/kubernetes/blob/master/api/openapi-spec/swagger.json)
-and Kedge [`spec.go`](https://github.com/kedgeproject/kedge/blob/master/pkg/spec/spec.go)
+and Kedge [`types.go`](https://github.com/kedgeproject/kedge/blob/master/pkg/spec/types.go)
 downloaded locally. For detailed steps see [manual steps](https://github.com/kedgeproject/json-schema-generator#doing-it-the-hard-way).
 
 ```bash
@@ -36,11 +36,11 @@ cd $GOPATH/src/github.com/kedgeproject/json-schema-generator
 curl -O https://raw.githubusercontent.com/kubernetes/kubernetes/$(curl https://raw.githubusercontent.com/kedgeproject/json-schema-generator/master/scripts/k8s-release)/api/openapi-spec/swagger.json
 ```
 
-Also we need to download the Kedge [`spec.go`](https://github.com/kedgeproject/kedge/blob/master/pkg/spec/spec.go)
+Also we need to download the Kedge [`types.go`](https://github.com/kedgeproject/kedge/blob/master/pkg/spec/types.go)
 file
 
 ```bash
-curl -O https://raw.githubusercontent.com/kedgeproject/kedge/master/pkg/spec/spec.go
+curl -O https://raw.githubusercontent.com/kedgeproject/kedge/master/pkg/spec/types.go
 ```
 
 Let's build the binary that generates OpenAPI schema for Kedge

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 func main() {
 	//log.SetLevel(log.DebugLevel)
 
-	defs, mapping, err := GenerateOpenAPIDefinitions("spec.go")
+	defs, mapping, err := GenerateOpenAPIDefinitions("types.go")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -15,18 +15,18 @@
 # limitations under the License.
 
 K8S_OPENAPI_URL=https://raw.githubusercontent.com/kubernetes/kubernetes/$(curl https://raw.githubusercontent.com/kedgeproject/json-schema-generator/master/scripts/k8s-release)/api/openapi-spec/swagger.json
-KEDGE_SPEC_URL=https://raw.githubusercontent.com/kedgeproject/kedge/master/pkg/spec/spec.go
+KEDGE_SPEC_URL=https://raw.githubusercontent.com/kedgeproject/kedge/master/pkg/spec/types.go
 
 echo "Downloading OpenAPI schema of Kubernetes from: $K8S_OPENAPI_URL"
 curl -O $K8S_OPENAPI_URL
 
-# Test if the spec.go exists, if it does don't download the file from URL
-cat spec.go > /dev/null
+# Test if the types.go exists, if it does don't download the file from URL
+cat types.go > /dev/null
 if [ $? -ne 0 ]; then
-	echo "Downloading 'spec.go' from $KEDGE_SPEC_URL"
+	echo "Downloading 'types.go' from $KEDGE_SPEC_URL"
 	curl -O $KEDGE_SPEC_URL
 else
-	echo "'spec.go' already exists."
+	echo "'types.go' already exists."
 fi
 
 echo "Generating OpenAPI schema for Kedge"


### PR DESCRIPTION
Move all the code and scripts that read from spec.go to types.go.