### PR TITLE
Revert "Output only controller specific JSON Schema"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,6 @@ var (
 	kedgeSpecLocation string
 	kubernetesSchema  string
 	openshiftSchema   string
-	isController      bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -28,7 +27,7 @@ var RootCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := pkg.Conversion(kedgeSpecLocation, kubernetesSchema, openshiftSchema, isController); err != nil {
+		if err := pkg.Conversion(kedgeSpecLocation, kubernetesSchema, openshiftSchema); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
@@ -47,5 +46,4 @@ func init() {
 	RootCmd.Flags().StringVarP(&kedgeSpecLocation, "kedgespec", "k", "types.go", "Specify the location of Kedge spec file")
 	RootCmd.Flags().StringVarP(&kubernetesSchema, "k8sSchema", "s", "swagger.json", "Specify the location of Kuberenetes Schema file")
 	RootCmd.Flags().StringVarP(&openshiftSchema, "osSchema", "o", "osv2.json", "Specify the location of OpenShift schema file")
-	RootCmd.Flags().BoolVarP(&isController, "controller", "c", true, "output only controller specific definitions")
 }

--- a/pkg/conversion.go
+++ b/pkg/conversion.go
@@ -47,7 +47,7 @@ func MergeDefinitions(target, src *openapi.OpenAPIDefinition) {
 	}
 }
 
-func Conversion(KedgeSpecLocation, KubernetesSchema, OpenShiftSchema string, controllerOnly bool) error {
+func Conversion(KedgeSpecLocation, KubernetesSchema, OpenShiftSchema string) error {
 	defs, mapping, err := GenerateOpenAPIDefinitions(KedgeSpecLocation)
 	if err != nil {
 		return err
@@ -72,24 +72,8 @@ func Conversion(KedgeSpecLocation, KubernetesSchema, OpenShiftSchema string, con
 	for k, v := range defs {
 		api.Schema.SchemaProps.Definitions[k] = v
 	}
-
-	if controllerOnly {
-		retainOnlyControllers(api.Schema.Definitions)
-	}
-
 	PrintJSONStdOut(api.Schema)
 	return nil
-}
-
-func retainOnlyControllers(definitions spec.Definitions) {
-	for k := range definitions {
-		switch k {
-		case "io.kedge.DeploymentSpecMod", "io.kedge.DeploymentConfigSpecMod", "io.kedge.JobSpecMod":
-			continue
-		default:
-			delete(definitions, k)
-		}
-	}
 }
 
 func augmentProperties(s, t spec.Schema) spec.Schema {


### PR DESCRIPTION
Reverts kedgeproject/json-schema-generator#27

This is resulting in invalid schema and needs to be reverted.